### PR TITLE
subscriber: don't block on connect

### DIFF
--- a/publisher.go
+++ b/publisher.go
@@ -128,6 +128,7 @@ func NewRedisPublisherWithBackoff(address string, handler PublicationHandler,
 func (p *redisPublisher) publishLoop() {
 	defer p.wg.Done()
 	for m := range p.messages {
+		m := m
 		func() {
 			conn := p.pool.Get()
 			defer conn.Close()

--- a/publisher_test.go
+++ b/publisher_test.go
@@ -42,6 +42,9 @@ func TestPublisherBasic(t *testing.T) {
 	p := NewRedisPublisher("localhost:6379", ph, 0, 0)
 	defer p.Shutdown()
 
+	// wait for connection
+	sh.waitUntilConnected()
+
 	count := 100
 	channels := []string{"foo", "bar", "hi"}
 
@@ -92,6 +95,9 @@ func TestPublisherBatch(t *testing.T) {
 	ph := &testPubHandler{t: t}
 	p := NewRedisPublisher("localhost:6379", ph, 1, 0)
 	defer p.Shutdown()
+
+	// wait for connection
+	sh.waitUntilConnected()
 
 	count := 100
 	channels := []string{"foo", "bar", "hi"}


### PR DESCRIPTION
@strib the unusual blocking you point out can actually be a practical problem for us. Right now we can handle disconnection from redis but if a server crashed it would block on restarting until redis is healthy again which isn't good. We don't ever want to block on a connection to redis so I didn't add a context. Connection either happens or it doesn't but the server should always handle it gracefully.
